### PR TITLE
텍스트가 잘리는 현상 수정

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_2_API_29.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-03-23T11:09:52.258523Z" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -149,7 +149,7 @@
         <entry key="app/src/main/res/layout/comment.xml" value="0.335" />
         <entry key="app/src/main/res/layout/comment_frame.xml" value="0.4123224419218621" />
         <entry key="app/src/main/res/layout/comment_recycler.xml" value="1.509493670886076" />
-        <entry key="app/src/main/res/layout/comment_reply.xml" value="0.6893063583815029" />
+        <entry key="app/src/main/res/layout/comment_reply.xml" value="0.4744341994970662" />
         <entry key="app/src/main/res/layout/comment_reply_recycler.xml" value="0.4185175577799479" />
         <entry key="app/src/main/res/layout/community_ingredient_recycler.xml" value="0.5276548672566371" />
         <entry key="app/src/main/res/layout/community_order_recycler.xml" value="0.5318697058636209" />

--- a/.idea/render.experimental.xml
+++ b/.idea/render.experimental.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="RenderSettings">
+    <option name="showDecorations" value="true" />
     <option name="useLiveRendering" value="false" />
   </component>
 </project>

--- a/app/src/main/java/com/example/solution_challenge_2022_vegather_app/CommentReplyActivity.kt
+++ b/app/src/main/java/com/example/solution_challenge_2022_vegather_app/CommentReplyActivity.kt
@@ -72,10 +72,6 @@ class CommentReplyActivity : AppCompatActivity() {
             val convertedData = it.toObject(UserForm::class.java)
             userName = convertedData?.NickName.toString()
         }
-
-        binding.name.text = commentInfo.nickname
-        binding.userText.text = commentInfo.text
-        binding.time.text = commentInfo.timestamp?.slice(0..10)
     }
 
     private fun getReplyComments(){

--- a/app/src/main/java/com/example/solution_challenge_2022_vegather_app/CommunityCommentReplyActivity.kt
+++ b/app/src/main/java/com/example/solution_challenge_2022_vegather_app/CommunityCommentReplyActivity.kt
@@ -67,10 +67,6 @@ class CommunityCommentReplyActivity : AppCompatActivity() {
             val convertedData = it.toObject(UserForm::class.java)
             userName = convertedData?.NickName.toString()
         }
-
-        binding.name.text = commentInfo.nickname
-        binding.userText.text = commentInfo.text
-        binding.time.text = commentInfo.timestamp?.slice(0..10)
     }
 
     private fun getReplyComments(){

--- a/app/src/main/res/layout/activity_comment_reply.xml
+++ b/app/src/main/res/layout/activity_comment_reply.xml
@@ -13,77 +13,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="5dp"
         android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
         android:backgroundTint="#00FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout14"
+        android:src="@drawable/x_btn_gray"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:src="@drawable/x_btn_gray" />
-
-    <LinearLayout
-        android:id="@+id/linearLayout14"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:background="@drawable/search_history_background_border"
-        android:orientation="horizontal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/imageButton3"
-        app:layout_constraintWidth_percent="0.95">
-
-        <ImageView
-            android:id="@+id/imageView2"
-            android:layout_width="130dp"
-            android:layout_height="60dp"
-            android:layout_weight="1"
-            android:src="@drawable/user_default_profile" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:paddingLeft="5dp"
-            android:paddingEnd="5dp">
-
-            <TextView
-                android:id="@+id/name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
-                android:layout_marginBottom="3dp"
-                android:text="John Yaml"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/userText"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="7dp"
-                android:text="Lorem Ipsum is simply dummy text of the printing and typesetting industry."
-                android:textSize="16sp" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center|start"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:id="@+id/time"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="7dp"
-                    android:text="2020.11.21"
-                    android:textColor="@color/sub_text_gray"
-                    android:textSize="14sp" />
-
-            </LinearLayout>
-        </LinearLayout>
-    </LinearLayout>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/replyRecycler"
@@ -92,7 +25,7 @@
         app:layout_constraintBottom_toTopOf="@+id/linearLayout15"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout14" />
+        app:layout_constraintTop_toBottomOf="@+id/imageButton3" />
 
     <LinearLayout
         android:id="@+id/linearLayout15"

--- a/app/src/main/res/layout/comment_reply.xml
+++ b/app/src/main/res/layout/comment_reply.xml
@@ -6,106 +6,26 @@
     android:layout_height="match_parent"
     android:background="#FFFFFF">
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView2"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/linearLayout11"
+        app:layout_constraintTop_toBottomOf="@+id/imageButton13">
+
+    </androidx.recyclerview.widget.RecyclerView>
+
     <ImageButton
         android:id="@+id/imageButton13"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:backgroundTint="#00FFFFFF"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout12"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.058"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/arrow_left_gray" />
-
-    <LinearLayout
-        android:id="@+id/linearLayout12"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:background="@drawable/search_history_background_border"
-        android:orientation="horizontal"
-        android:paddingBottom="5dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/imageButton13"
-        app:layout_constraintWidth_percent="0.9">
-
-        <ImageView
-            android:id="@+id/imageView2"
-            android:layout_width="150dp"
-            android:layout_height="70dp"
-            android:layout_weight="1"
-            app:srcCompat="@drawable/user_default_profile" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:paddingLeft="15dp">
-
-            <TextView
-                android:id="@+id/textView38"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:text="John Yaml"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/textView39"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="5dp"
-                android:lineSpacingExtra="5dp"
-                android:text="Lorem Ipsum is simply dummy text of the printing and typesetting industry."
-                android:textSize="16sp" />
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center|start"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:id="@+id/textView40"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="9dp"
-                    android:text="2020.11.21"
-                    android:textColor="@color/sub_text_gray" />
-
-                <ImageButton
-                    android:id="@+id/likeImageView"
-                    android:layout_width="20dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="3dp"
-                    android:backgroundTint="#00FFFFFF"
-                    app:srcCompat="@drawable/heart_icon" />
-
-                <TextView
-                    android:id="@+id/like"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="10dp"
-                    android:text="999+"
-                    android:textColor="@color/sub_text_gray" />
-
-            </LinearLayout>
-        </LinearLayout>
-    </LinearLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="20dp"
-        app:layout_constraintBottom_toTopOf="@+id/linearLayout11"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout12" />
 
     <LinearLayout
         android:id="@+id/linearLayout11"

--- a/app/src/main/res/layout/comment_reply_recycler.xml
+++ b/app/src/main/res/layout/comment_reply_recycler.xml
@@ -10,7 +10,6 @@
         android:layout_marginTop="10dp"
         android:layout_marginBottom="10dp"
         android:orientation="horizontal"
-        android:paddingStart="20dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/main_page_more_recipe_recycler.xml
+++ b/app/src/main/res/layout/main_page_more_recipe_recycler.xml
@@ -49,7 +49,9 @@
                 android:id="@+id/foodName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:ellipsize="end"
                 android:hint="@string/textLoading"
+                android:maxLines="1"
                 android:textColorHint="@color/sub_text_gray"
                 android:textSize="20sp"
                 android:textStyle="bold" />
@@ -57,7 +59,7 @@
             <TextView
                 android:id="@+id/foodInfo"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
                 android:layout_marginBottom="10dp"
                 android:ellipsize="end"
@@ -73,7 +75,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
-            android:layout_weight="0"
             android:gravity="center_vertical"
             android:orientation="horizontal">
 


### PR DESCRIPTION
1. 더 많은 레시피에서 음식 소개 텍스트가 잘리는 현상을 막기 위해 maxLine을 설정해 줄이 넘치지 않도록 해결했습니다.

2. 답글창에서 댓글 내용이 매우 길면 밑의 댓글의 리사이클러 뷰가 아래로 가라앉는 현상이 있었습니다. 이를 해결하기 위해 맨 위에 원댓글이 있던 공간을 없애고 전부 답글만 나오도록 리사이클러 뷰 하나만 채웠습니다.