### PR TITLE
레시피 재료 체크기능에서 발생한 오류를 수정

### DIFF
--- a/app/src/main/java/com/example/solution_challenge_2022_vegather_app/IngredientAdapter.kt
+++ b/app/src/main/java/com/example/solution_challenge_2022_vegather_app/IngredientAdapter.kt
@@ -12,6 +12,7 @@ class IngredientAdapter(private val binding : IngredientRecyclerBinding) :
             RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val dataset = ArrayList<String>()
+    private val isSelected = HashMap<String,Boolean>()
 
     inner class IngredientViewHolder(val binding : IngredientRecyclerBinding) :
         RecyclerView.ViewHolder(binding.root){
@@ -22,14 +23,24 @@ class IngredientAdapter(private val binding : IngredientRecyclerBinding) :
                 IngredientRecyclerBinding.inflate(LayoutInflater.from(parent.context),parent,false))
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        Log.d("Check",dataset[position] + isSelected[dataset[position]] )
         val binding = (holder as IngredientAdapter.IngredientViewHolder).binding
         binding.radioButton.text = dataset[position]
+        binding.radioButton.isChecked = isSelected[dataset[position]] != false
+
         binding.radioButton.setOnCheckedChangeListener { buttonView, isChecked ->
+            Log.d("Check",isChecked.toString())
             when(isChecked){
-                true -> buttonView.setTextColor(Color.parseColor("#81E768"))
-                false -> buttonView.setTextColor(Color.parseColor("#BCBCBC"))
+                true -> {
+                    buttonView.setTextColor(Color.parseColor("#81E768"))
+                }
+                false -> {
+                    buttonView.setTextColor(Color.parseColor("#BCBCBC"))
+                }
             }
+            isSelected[buttonView.text.toString()] = isChecked
         }
+
     }
 
     override fun getItemCount(): Int {
@@ -37,8 +48,9 @@ class IngredientAdapter(private val binding : IngredientRecyclerBinding) :
     }
 
     fun setData(data : RecipeInformation){
-        for (text in data.ingredient)
+        for (text in data.ingredient){
             dataset.add(text)
+            isSelected[text] = false
+        }
     }
-
 }


### PR DESCRIPTION
특정 재료를 체크하면 다른 재료가 같이 체크되는 중복체크 현상을 고쳤습니다.
리사이클러 뷰 재사용에서 나온 문제인 것 같습니다.
HashMap으로 실시간 체크현황을 저장하고 뷰를 다시 재사용 할 때 이 HashMap에서 체크현황을 검색해 체크박스의 체크를 설정합니다.